### PR TITLE
relax upper bound on base for ghc 8.0.x.

### DIFF
--- a/har.cabal
+++ b/har.cabal
@@ -47,7 +47,7 @@ library
 
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.6 && <4.8
+  build-depends:       base >=4.6 && <5.0
                      , aeson
                      , bytestring
                      , directory


### PR DESCRIPTION
This allows the package to compile with ghc 8.0.x, tested with ghc 8.0.2.